### PR TITLE
Include script directory in @INC

### DIFF
--- a/barcoder.pl
+++ b/barcoder.pl
@@ -16,4 +16,6 @@
 #
 #########################################
 use strict;
+use FindBin 1.51 qw( $RealBin );
+use lib $RealBin;
 require 'Code/barcode_main.pl';


### PR DESCRIPTION
Fixes #6

This is the fix recommended by https://stackoverflow.com/questions/41414782/cant-locate-in-inc-perl-perl-file-loaded-by-require

Without it we get the error:

```
$ perl barcoder.pl BTK 2
Can't locate Code/barcode_main.pl in @INC (@INC contains: /usr/local/lib64/perl5 /usr/local/share/perl5 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at barcoder.pl line 19.
```